### PR TITLE
chore: fixed eslint, part 2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
 
     "rules": {
       "max-len": "off",
-      "mocha/no-exclusive-tests": "error"
+      "mocha/no-exclusive-tests": "error",
+      "strict": [2, "never"]
     }
 }

--- a/lib/config/configFile.js
+++ b/lib/config/configFile.js
@@ -1,5 +1,3 @@
-'use strict';
-
 process.env['NODE_CONFIG_DIR'] = __dirname;
 const config = require('config');
 

--- a/lib/google-suite.js
+++ b/lib/google-suite.js
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
-
 const log = require('./util/logger.js');
 
 const {google} = require('googleapis');
@@ -136,7 +134,7 @@ const gsuiteOperations = {
     }
 
     if (result.code_update && result.code_photo){
-      result.status = result.code_update != result.code_photo ? '207' : result.code_update;
+      result.status = result.code_update !== result.code_photo ? '207' : result.code_update;
     } else {
       result.status = result.code_photo ? result.code_photo : result.code_update;
     }

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,5 +1,6 @@
 const { errors } = require('oms-common-nodejs');
 const serverInfo = require('./util/info.js');
+const packageInfo = require('../package.json');
 
 const log = require('./util/logger.js');
 

--- a/lib/util/info.js
+++ b/lib/util/info.js
@@ -1,4 +1,3 @@
-'use strict';
 const os = require('os');
 
 const host = () => {

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,4 +1,3 @@
-'use strict';
 const winston = require('winston');
 
 // Setting logLevel to warn in case of testing, to display only errors and warnings.

--- a/lib/util/swaggerDef.js
+++ b/lib/util/swaggerDef.js
@@ -1,5 +1,5 @@
-'use strict';
 const config = require('../config/configFile.js');
+
 module.exports = {
   info: {
     // API informations (required)


### PR DESCRIPTION
part 2 of greenifying eslint check

this is what's left after this is merged and I'm kinda scared to change/fix this as I don't know what happens inside, @linuxbandit can you update it once this is merged?

```

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/lib/google-suite.js
   41:5   error  Expected an error object to be thrown  no-throw-literal
   70:11  error  'GsuiteError' is not defined           no-undef
   75:11  error  'GsuiteError' is not defined           no-undef
  227:11  error  'GsuiteError' is not defined           no-undef

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/accounts.test.js
   2:7  error  'should' is assigned a value but never used  no-unused-vars
  48:5  error  'pip' is not defined                         no-undef
  51:5  error  'pip' is not defined                         no-undef
  52:5  error  'pip' is not defined                         no-undef
  53:5  error  'pip' is not defined                         no-undef
  54:5  error  'pip' is not defined                         no-undef

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/aliases.test.js
    2:7  error  'should' is assigned a value but never used  no-unused-vars
   85:5  error  'pip' is not defined                         no-undef
   88:5  error  'pip' is not defined                         no-undef
   89:5  error  'pip' is not defined                         no-undef
   90:5  error  'pip' is not defined                         no-undef
   91:5  error  'pip' is not defined                         no-undef
   92:5  error  'pip' is not defined                         no-undef
  279:9  error  'body' is not defined                        no-undef
  281:9  error  'body' is not defined                        no-undef

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/events.test.js
  2:7  error  'should' is assigned a value but never used  no-unused-vars

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/groups.test.js
    2:7   error  'should' is assigned a value but never used  no-unused-vars
  181:16  error  Expected error to be handled                 handle-callback-err
  197:16  error  Expected error to be handled                 handle-callback-err

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/memberships.test.js
    2:7  error  'should' is assigned a value but never used  no-unused-vars
  102:5  error  'pip' is not defined                         no-undef
  103:5  error  'pip' is not defined                         no-undef
  104:5  error  'pip' is not defined                         no-undef
  106:5  error  'pip' is not defined                         no-undef
  107:5  error  'pip' is not defined                         no-undef
  108:5  error  'pip' is not defined                         no-undef
  109:5  error  'pip' is not defined                         no-undef

/Users/sergeypeshkov/oms-docker/gsuite-wrapper/test/redis.test.js
  2:7   error  'should' is assigned a value but never used  no-unused-vars
  7:10  error  'delay' is defined but never used            no-unused-vars

✖ 33 problems (33 errors, 0 warnings)
```