### PR TITLE
ci(config): update ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ jobs:
       - run:
           name: Run tests
           command: npm test
-    #  - run: ./node_modules/.bin/codecov
-    #  - store_test_results:
-    #      path: ~/reports
-    #  - store_artifacts:
-    #      path: ~/reports
+      # - run: ./node_modules/.bin/codecov
+      # - store_test_results:
+      #     path: ~/reports
+      # - store_artifacts:
+      #     path: ~/reports
   build:
     docker:
       - image: cimg/base:2021.03
@@ -82,7 +82,7 @@ jobs:
           version: 20.10.2
       - node/install-packages
       - run: npx semantic-release
-      - run: docker build  --tag aegee/gsuite-wrapper:$(node -p "require('./package.json').version") --tag aegee/gsuite-wrapper:latest -f docker/gsuite-wrapper/Dockerfile .
+      - run: docker build  --tag aegee/gsuite-wrapper:$(node -p "require('./package.json').version") --tag aegee/gsuite-wrapper:latest -f docker/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/gsuite-wrapper:$(node -p "require('./package.json').version")
       - run: docker push aegee/gsuite-wrapper:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,49 @@
 orbs:
-  slack: circleci/slack@3.4.1
+  slack: circleci/slack@3.4.2 # FIXME update to v4
+  node: circleci/node@4.2.0
+  shellcheck: circleci/shellcheck@2.2.2
+  docker: circleci/docker@1.5.0
 version: 2.1
 jobs:
   test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
+      - run: docker run --name redis-gsuite-wrapper -d redis
       - run:
           name: Install Node
           command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
-      - run: mkdir -p ~/reports/jest
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo ' [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            nvm install v14.16.0
+            nvm alias default v14.16.0
+      - node/install-packages
+      - run: cat $SERVICEACCOUNT_JSON > ~/lib/config/myaegee-serviceaccount.json
+      - run: cat $SECRETS_JSON > ~/lib/config/secrets.json
+      - run: mkdir -p ~/reports/mocha
       - run:
           name: Run tests
           command: npm test
-      # - run: ./node_modules/.bin/codecov
-      # - store_test_results:
-      #     path: ~/reports
-      # - store_artifacts:
-      #     path: ~/reports
+    #  - run: ./node_modules/.bin/codecov
+    #  - store_test_results:
+    #      path: ~/reports
+    #  - store_artifacts:
+    #      path: ~/reports
   build:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/base:2021.03
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.2
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache gsuite-wrapper
   eslint:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/node:14.16.0
     steps:
       - checkout
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
+      - node/install-packages
       - run: mkdir -p ~/reports
       - run: npm run lint -- --format junit --output-file ~/reports/eslint.xml
       - store_test_results:
@@ -50,27 +51,38 @@ jobs:
       - store_artifacts:
           path: ~/reports
   yamllint:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      - image: cimg/python:3.9.2
     steps:
       - checkout
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
-  docker-build-and-push:
-    machine:
-      image: ubuntu-1604:201903-01
+  shellcheck:
+    docker:
+      - image: cimg/base:2021.03
     steps:
       - checkout
-      - run:
-          name: Install Node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            echo 'export PATH=/usr/bin:$PATH' >> $BASH_ENV
-            which node && node -v
-      - run: npm install
+      - shellcheck/install
+      - shellcheck/check
+  audit:
+    docker:
+      - image: cimg/node:14.16.0
+    steps:
+      - checkout
+      - run: npm audit --production
+      - slack/status:
+          fail_only: true
+          failure_message: The audit check for \`$CIRCLE_PROJECT_REPONAME\` has failed.
+  docker-build-and-push:
+    docker:
+      - image: cimg/node:14.16.0
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.2
+      - node/install-packages
       - run: npx semantic-release
-      - run: docker build  --tag aegee/gsuite-wrapper:$(node -p "require('./package.json').version") --tag aegee/gsuite-wrapper:latest -f docker/Dockerfile .
+      - run: docker build  --tag aegee/gsuite-wrapper:$(node -p "require('./package.json').version") --tag aegee/gsuite-wrapper:latest -f docker/gsuite-wrapper/Dockerfile .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/gsuite-wrapper:$(node -p "require('./package.json').version")
       - run: docker push aegee/gsuite-wrapper:latest
@@ -80,24 +92,34 @@ jobs:
 
 workflows:
   version: 2
-  test:
-    jobs:
-      - test
-  eslint:
+  linters:
     jobs:
       - eslint
+      - yamllint
+      - shellcheck
+      - docker/hadolint:
+          dockerfiles: $(find . -name '*Dockerfile*')
   build:
     jobs:
       - build:
           filters:
             branches:
               ignore: master
-  yamllint:
+  test:
     jobs:
-      - yamllint
+      - test
   docker-build-and-push:
     jobs:
       - docker-build-and-push:
           filters:
             branches:
               only: master
+  audit:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 5"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ jobs:
             nvm install v14.16.0
             nvm alias default v14.16.0
       - node/install-packages
-      - run: cat $SERVICEACCOUNT_JSON > ~/lib/config/myaegee-serviceaccount.json
-      - run: cat $SECRETS_JSON > ~/lib/config/secrets.json
+      - run: echo $SERVICEACCOUNT_JSON > lib/config/myaegee-serviceaccount.json
+      - run: echo $SECRETS_JSON > lib/config/secrets.json
       - run: mkdir -p ~/reports/mocha
       - run:
           name: Run tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14.16.1
 
 WORKDIR /usr/app/src
 


### PR DESCRIPTION
This PR updates the CircleCI config to the other PRs, it also updates the system to Node 14.
Tests are completely working yet, they post the proper things to GSuite but it doesn't connect with the redis database yet.

`[ioredis] Unhandled error event: Error: getaddrinfo EAI_AGAIN redis-gsuite-wrapper
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:67:26)`

Probably a relatively easy fix, but it's late so I couldn't really figure it out. @linuxbandit @serge1peshcoff any ideas?

Because redis is not connected, things don't get removed automatically. I manually removed the user and the group, but I could not remove the event. @linuxbandit I don't believe that calendar is used, but are you able to remove the event?